### PR TITLE
Add a 'default' htpasswd option.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@ build-image:
  services:
   - docker:dind
  script:
+    - apk add --no-cache curl
     - docker login -u gitlab-ci-token -p $CI_BUILD_TOKEN registry.gitlab.com
     - version_available=$(curl --write-out %{http_code} --silent --output /dev/null https://gitlab.com/adi90x/rancher-gen-rap/builds/artifacts/$CI_BUILD_REF_NAME/browse?job=compile-go)
     - if [ $version_available == "302" ]; then build_version=artifacts/$CI_BUILD_REF_NAME; else build_version="artifacts/master"; fi

--- a/README.md
+++ b/README.md
@@ -306,6 +306,8 @@ Or you can use an nginx container to create the file ( using OpenSSL as explaine
 
 `docker run -it nginx printf "Username_to_use:$(openssl passwd -crypt Password_to_use)\n" >> /path/to/htpasswd/{rap.host}`
 
+A default htpasswd can be used to secure all hosts using this proxy. Good for development environments to keep prying eyes out. To use, create the htpasswd file named 'default' here: `/etc/nginx/htpasswd/default`.
+
 ### Custom Nginx Configuration
 
 If you need to configure Nginx beyond what is possible using environment variables, you can provide custom configuration files on either a proxy-wide or per-`rap.host` basis.

--- a/app/nginx.tmpl
+++ b/app/nginx.tmpl
@@ -6,7 +6,7 @@
     upstream {{.HOST}} {
 	#Access through rancher managed network
 	server {{.IP}}:{{.PORT}};
-{{- end -}}	
+{{- end -}}
 {{ end }}
 
 {{ define "server" }}
@@ -41,7 +41,7 @@ include /etc/nginx/vhost.d/default_server;
 
 {{- if $is_https }}
 
-{{- if eq $https_method "redirect" }} 
+{{- if eq $https_method "redirect" }}
 server {
 	server_name {{ $host }};
 	{{- range $port := $http_ports }}
@@ -64,17 +64,17 @@ server {
 	listen {{$port}} ssl http2 {{ $default_server }};
 	{{- end }}
 	access_log /var/log/nginx/access.log vhost;
-	
+
 	{{- if (ne $token "") }}
 	server_tokens {{$token}};
 	{{- end }}
 	{{- if (ne $body_size "") }}
 	client_max_body_size {{$body_size}};
 	{{- end }}
-	
+
 	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:!DSS';
-	
+
 	ssl_prefer_server_ciphers on;
 	ssl_session_timeout 5m;
 	ssl_session_cache shared:SSL:50m;
@@ -107,6 +107,9 @@ server {
 		{{- if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";
 		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+    {{- else if (exists (printf "/etc/nginx/htpasswd/%s" "default")) }}
+    auth_basic	"Restricted {{ $host }}";
+		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" "default") }};
 		{{- end }}
         	{{- if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
         	include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
@@ -127,14 +130,14 @@ server {
 	listen {{$port}}  {{ $default_server }};
 	{{- end }}
 	access_log /var/log/nginx/access.log vhost;
-		
+
 	{{- if (ne $token "") }}
 	server_tokens {{$token}};
 	{{- end }}
 	{{- if (ne $body_size "") }}
 	client_max_body_size {{$body_size}};
 	{{- end }}
-	
+
 	{{- if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
 	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
 	{{- else if (exists "/etc/nginx/vhost.d/default") }}
@@ -151,6 +154,9 @@ server {
 		{{- if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";
 		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+    {{- else if (exists (printf "/etc/nginx/htpasswd/%s" "default")) }}
+    auth_basic	"Restricted {{ $host }}";
+		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" "default") }};
 		{{- end }}
         	{{- if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
         	include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
@@ -168,14 +174,14 @@ server {
 	listen {{$port}} ssl http2 {{ $default_server }};
 	{{- end }}
 	access_log /var/log/nginx/access.log vhost;
-		
+
 	{{- if (ne $token "") }}
 	server_tokens {{$token}};
 	{{- end }}
 	{{- if (ne $body_size "") }}
 	client_max_body_size {{$body_size}};
 	{{- end }}
-	
+
 	return 500;
 
 	ssl_certificate /etc/nginx/certs/default.crt;
@@ -362,4 +368,3 @@ server {
 {{ end -}}
 {{- end -}}
 {{- end -}}
-


### PR DESCRIPTION
The changes in this pull request allow for a default .htpasswd to be used for all hosts that are using the proxy.

The need for this arose when we needed to keep search engines away from staging/review environments.