### PR TITLE
Added "ACME_INTERNAL" env

### DIFF
--- a/app/nginx.tmpl
+++ b/app/nginx.tmpl
@@ -274,7 +274,7 @@ server {
 		{{- end }}
 		{{- end }}
 	access_log /var/log/nginx/access.log vhost;
-	{{ - if (env ACME_INTERNAL) }}
+	{{- if (env ACME_INTERNAL) }}
 	location / {
 		return 503;
 	}

--- a/app/nginx.tmpl
+++ b/app/nginx.tmpl
@@ -274,7 +274,19 @@ server {
 		{{- end }}
 		{{- end }}
 	access_log /var/log/nginx/access.log vhost;
+	{{ - if (env $acme_internal) }}
+	location / {
+		return 503;
+	}
+	location /.well-known {
+		proxy_pass $acme_internal
+		proxy_set_header X-Real-IP $remote_addr;
+      		proxy_set_header Host $host;
+      		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+	}
+	{{- else }}
 	return 503;
+	{{- end }}
 }
 
 {{- if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}

--- a/app/nginx.tmpl
+++ b/app/nginx.tmpl
@@ -275,7 +275,7 @@ server {
 		{{- end }}
 		{{- end }}
 	access_log /var/log/nginx/access.log vhost;
-	{{- if (ne $acme_internal "") }}
+	{{ if (ne $acme_internal "") -}}
 	location / {
 		return 503;
 	}
@@ -286,8 +286,7 @@ server {
       		proxy_set_header Host $host;
       		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	}
-	{{- end }}
-	{{- if (eq $acme_internal) }}
+	{{- else -}}
 	return 503;
 	{{- end }}
 }

--- a/app/nginx.tmpl
+++ b/app/nginx.tmpl
@@ -286,7 +286,8 @@ server {
       		proxy_set_header Host $host;
       		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	}
-	{{- else }}
+	{{- end }}
+	{{- if (eq $acme_internal) }}
 	return 503;
 	{{- end }}
 }

--- a/app/nginx.tmpl
+++ b/app/nginx.tmpl
@@ -280,7 +280,7 @@ server {
 	}
 	
 	{{- if (ne $acme_internal "") }}
-	location /.well-known {
+	location /.well-known { # This allows proxy acme requests to pass through to another server.
 		proxy_pass http://{{ $acme_internal }}/.well-known;
 		proxy_set_header X-Real-IP $remote_addr;
       		proxy_set_header Host $host;

--- a/app/nginx.tmpl
+++ b/app/nginx.tmpl
@@ -279,7 +279,7 @@ server {
 		return 503;
 	}
 	
-	{{- if (ne $acme_internal "") }}
+	{{ if (ne $acme_internal "") }}
 	location /.well-known {
 		proxy_pass {{ $acme_internal }};
 		{{- end }}
@@ -287,7 +287,7 @@ server {
       		proxy_set_header Host $host;
       		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	}
-	{{- end }}
+	{{ end }}
 }
 
 {{- if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}

--- a/app/nginx.tmpl
+++ b/app/nginx.tmpl
@@ -281,7 +281,7 @@ server {
 	
 	{{- if (ne $acme_internal "") }}
 	location /.well-known {
-		proxy_pass {{ $acme_internal }};
+		proxy_pass http://{{ $acme_internal }}/.well-known;
 		proxy_set_header X-Real-IP $remote_addr;
       		proxy_set_header Host $host;
       		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/app/nginx.tmpl
+++ b/app/nginx.tmpl
@@ -279,15 +279,14 @@ server {
 		return 503;
 	}
 	
-	{{ if (ne $acme_internal "") }}
+	{{- if (ne $acme_internal "") }}
 	location /.well-known {
 		proxy_pass {{ $acme_internal }};
-		{{- end }}
 		proxy_set_header X-Real-IP $remote_addr;
       		proxy_set_header Host $host;
       		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	}
-	{{ end }}
+	{{- end }}
 }
 
 {{- if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}

--- a/app/nginx.tmpl
+++ b/app/nginx.tmpl
@@ -265,6 +265,7 @@ proxy_set_header Proxy "";
 {{- $https_ports_stand := host.Containers | getAllLabelValue "" "rap.https_listen_ports" ","}}
 {{- $https_ports := concatenateUnique $https_ports_services $https_ports_stand }}
 
+{{- $acme_internal := (env "ACME_INTERNAL") "" }}
 server {
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
 	listen 80;
@@ -274,12 +275,11 @@ server {
 		{{- end }}
 		{{- end }}
 	access_log /var/log/nginx/access.log vhost;
-	{{- if (env ACME_INTERNAL) }}
+	{{- if (ne $acme_internal "") }}
 	location / {
 		return 503;
 	}
 	location /.well-known {
-		{{- with $acme_internal := (env ACME_INTERNAL) }}
 		proxy_pass $acme_internal
 		{{- end }}
 		proxy_set_header X-Real-IP $remote_addr;

--- a/app/nginx.tmpl
+++ b/app/nginx.tmpl
@@ -274,12 +274,14 @@ server {
 		{{- end }}
 		{{- end }}
 	access_log /var/log/nginx/access.log vhost;
-	{{ - if (env $acme_internal) }}
+	{{ - if (env ACME_INTERNAL) }}
 	location / {
 		return 503;
 	}
 	location /.well-known {
+		{{- with $acme_internal := (env ACME_INTERNAL) }}
 		proxy_pass $acme_internal
+		{{- end }}
 		proxy_set_header X-Real-IP $remote_addr;
       		proxy_set_header Host $host;
       		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/app/nginx.tmpl
+++ b/app/nginx.tmpl
@@ -275,19 +275,18 @@ server {
 		{{- end }}
 		{{- end }}
 	access_log /var/log/nginx/access.log vhost;
-	{{ if (ne $acme_internal "") -}}
 	location / {
 		return 503;
 	}
+	
+	{{- if (ne $acme_internal "") }}
 	location /.well-known {
-		proxy_pass $acme_internal
+		proxy_pass {{ $acme_internal }};
 		{{- end }}
 		proxy_set_header X-Real-IP $remote_addr;
       		proxy_set_header Host $host;
       		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	}
-	{{- else -}}
-	return 503;
 	{{- end }}
 }
 


### PR DESCRIPTION
Added the "ACME_INTERNAL" env to pipe acme requests to other RAP instances (IE using RAP_NAME).

note: a shared / sync'd folder should be used for letsencrypt data for best results.